### PR TITLE
Don't die when cleaning up test files on macOS

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,12 +36,7 @@ def delete_generated_files test_case, example=nil
   dir = dir_str test_case
   test_case = example if example
   Dir.chdir(dir) do
-    [
-      "#{test_case}.c", "#{test_case}.so", "Makefile",
-      "extconf.rb"    , "#{test_case}.o"
-    ].each do |f|
-      FileUtils.rm f
-    end
+    FileUtils.rm Dir.glob("#{test_case}.{c,so,o,bundle}") + ["Makefile", "extconf.rb"]
   end
 end
 


### PR DESCRIPTION
On my attempt to look into #31 I noticed that we clean up build-remains after a test run in `spec_helper.rb`. There we expect a file named `#{test_case}.so` which does not exist on macOS (it's called `#{test_case}.bundle`).

This PR changes the way we clean up build remains to be a little more flexible, so it should work on linux and macOS.