### PR TITLE
Change on reverse.each

### DIFF
--- a/lib/rubex/ast/top_statement/klass/attached_klass.rb
+++ b/lib/rubex/ast/top_statement/klass/attached_klass.rb
@@ -389,7 +389,7 @@ module Rubex
           stmts = []
           stmts << data_var_cptr_decl(nil)
           stmts.concat data_struct_allocations
-          stmts.reverse.each do |s|
+          stmts.reverse_each do |s|
             func.statements.unshift s
           end
         end


### PR DESCRIPTION
Change on reverse_each because reverse_each loops in reverse order (no
intermediate array created).